### PR TITLE
Remove merge conflict lines from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-<<<<<<< HEAD
 reformat_missing_logfile.py
 get_from_cloudloop.py
 docker_data/*
-*.log
-=======
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -166,4 +164,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
->>>>>>> 0834e2ebce2c9b26723f6fece65932c8fae8ce01


### PR DESCRIPTION
Some git conflict resolution lines have been committed to .gitignore in error - remove these, as well as the duplicated *.log entry and assume all remaining ignore lines are required.